### PR TITLE
Addition of a Node Labelling Term

### DIFF
--- a/code/FAQ/Tests/Isomorphism.m
+++ b/code/FAQ/Tests/Isomorphism.m
@@ -1,28 +1,33 @@
-% FAQ should solve QAP exactly when A and B are adjacency matrices  of
-% simple graphs and are isomorphic to one another
+% FAQ test where A and B are adjacency matrices  of
+% simple graphs and are isomorphic to one another. We hope to see the graph
+% matching distance as 0 although this will not be the case if rQAP
+% converges to a local minimum.
 
 % Define test dimension
-p = 5;
+n = 10;
 
 % Define A as a random adjacenecy matrix of a simple graph
 % To do this we need p(p-1)/2 Bernoulli trials for each edge
-A = zeros(p);
-for i = 1:p-1
-    for j = i+1:p
+A = zeros(n);
+for i = 1:n-1
+    for j = i+1:n
         A(i,j) = rand() > 0.5;
         A(j,i) = A(i,j);
     end
 end
 
 % Now generate a random permutation matrix
-P = perm2mat( randperm(p) );
+P = perm2mat( randperm(n) );
 
 % Produce an isomorphic B
 B = P * A * P';
 
 % Now run sfw and check the permutation transforms A onto B
-[~, sfw_p] = sfw(-A, B);  % Note we use -A as sfw solves QAP
-sfw_P = perm2mat(sfw_p);
+% [~, sfw_p] = sfw(-A, B);  % Note we use -A as sfw solves QAP
+% sfw_P = perm2mat(sfw_p);
 
-assert(all(all(A == sfw_P * B * sfw_P')))
+[f, ~, sfw_P, Q] = graphm_sfw(A, B);
+
+fprintf('\nGraph matching error (optimal is 0): %g\n', f)
+
 

--- a/code/FAQ/Tests/Isomorphism.m
+++ b/code/FAQ/Tests/Isomorphism.m
@@ -1,0 +1,28 @@
+% FAQ should solve QAP exactly when A and B are adjacency matrices  of
+% simple graphs and are isomorphic to one another
+
+% Define test dimension
+p = 5;
+
+% Define A as a random adjacenecy matrix of a simple graph
+% To do this we need p(p-1)/2 Bernoulli trials for each edge
+A = zeros(p);
+for i = 1:p-1
+    for j = i+1:p
+        A(i,j) = rand() > 0.5;
+        A(j,i) = A(i,j);
+    end
+end
+
+% Now generate a random permutation matrix
+P = perm2mat( randperm(p) );
+
+% Produce an isomorphic B
+B = P * A * P';
+
+% Now run sfw and check the permutation transforms A onto B
+[~, sfw_p] = sfw(-A, B);  % Note we use -A as sfw solves QAP
+sfw_P = perm2mat(sfw_p);
+
+assert(all(all(A == sfw_P * B * sfw_P')))
+

--- a/code/FAQ/Tests/LabelledVsUnLabelled.m
+++ b/code/FAQ/Tests/LabelledVsUnLabelled.m
@@ -1,0 +1,57 @@
+% This tests how well we can match graphs with vertex labellings
+
+% Define test dimension
+n = 10;
+
+% Define A as a random adjacenecy matrix of a simple graph
+% To do this we need p(p-1)/2 Bernoulli trials for each edge
+A = zeros(n);
+for i = 1:n-1
+    for j = i+1:n
+        A(i,j) = rand() > 0.5;
+        A(j,i) = A(i,j);
+    end
+end
+
+% Now generate a random permutation matrix
+P = perm2mat( randperm(n) );
+
+% Produce an isomorphic B
+B = P * A * P';
+
+% Create labellings
+C = rand(n);
+for i = 1:n
+    % Now make it so there is a perfect labelling
+    C(i,i) = 0;
+end
+C = C * P;
+
+%%%%%%%%%%%%%%%%%% Test 1: alpha = 0 %%%%%%%%%%%%%%%%%%%%%%
+% When alpha is set to 0 we don't care about vertex labellings so should
+% find the isomorphic distance
+
+[f, ~, sfw_P, Q] = graphm_sfw(A, B, 30, -1, C, 0);
+
+fprintf('\nGraph matching error with alpha = 0 (optimal is 0): %g\n', f)
+
+%%%%%%%%%%%%%%%%%% Test 2: alpha = 1 %%%%%%%%%%%%%%%%%%%%%%
+% When alpha is set to 1 we only care about vertex labellings so our best
+% answer should be the minimum of the LAP tr(C^T P)
+
+[f, ~, sfw_P, Q] = graphm_sfw(A, B, 30, -1, C, 1);
+
+% Now find the pure LAP
+[p,w,x] = assign(-C);
+
+fprintf('\nGraph matching error with alpha = 1 (optimal is %g): %g\n',-w, f)
+
+%%%%%%%%%%%%%%%%%% Test 3: alpha = 0.5 %%%%%%%%%%%%%%%%%%%%%%
+% When alpha is set to 0.5 we get a mixture between structural and labelled
+
+[f, ~, sfw_P, Q] = graphm_sfw(A, B, 30, -1, C, 0.5);
+
+% Now find the pure LAP
+[p,w,x] = assign(-C);
+
+fprintf('\nGraph matching error with alpha = 0.5 (optimal is 0): %g\n', f)

--- a/code/FAQ/fun.m
+++ b/code/FAQ/fun.m
@@ -1,4 +1,4 @@
-function [f0] = fun(x,A,B)
+function [f0] = fun(x,A,B,C,alpha)
 % function [f0] = fun(x,A,B)
 %--------------------
 % Louis J. Podrazik circa 1996
@@ -11,5 +11,5 @@ function [f0] = fun(x,A,B)
 
 [m,n]=size(A);
 [P,Q]=unstack(x,m,n);
-f0=sum(sum(P*A*Q'.*B));
+f0 = 2*(1-alpha)*trace(P*A*Q'*B) + alpha * trace(C'*P);  % Labelled graph matching equation
 %f0=-f0; % MINIMIZATION

--- a/code/FAQ/fungrad.m
+++ b/code/FAQ/fungrad.m
@@ -1,4 +1,4 @@
-function [f0, g ] = fungrad(x,A,B)
+function [f0, g ] = fungrad(x,A,B,C,alpha)
 %function [f0, g ] = fungrad(x,A,B)
 % gradient (all matrix level computations)
 %
@@ -9,16 +9,19 @@ function [f0, g ] = fungrad(x,A,B)
 %
 %     This material may be reproduced by or for the U.S. Government pursuant to the copyright license under the clauses at DFARS 252.227-7013 and 252.227-7014.
 %
-
-[m,n]=size(A);
-[P,Q]=unstack(x,m,n);
-%f0=sum(sum(P*A*Q'.*B));
-f0=fun(x,A,B);
-%Note sum(sum((P*A*Q').*B))=sum(sum(B*Q*A').*P)
-%  so grad wrt to P is  B*Q*A'
-g=reshape(B*Q*A',m*m,1);
-%Note sum(sum((P*A*Q').*B))=sum(sum(B'*P*A).*Q)
-%  so grad wrt to P is  B*Q*A'
-%g=-[g;reshape(B'*P*A,n*n,1)];
-g=[g;reshape(B'*P*A,n*n,1)];
+    
+    % In http://arxiv.org/pdf/1112.5507v5.pdf it looks as though the
+    % objective function is tr(A P B^T P^T) but here it suggests it is
+    % tr(B^T Q A^T P^T) = tr(P A Q^T B)
+    [m,n]=size(A);
+    [P,Q]=unstack(x,m,n);
+    %f0=sum(sum(P*A*Q'.*B));
+    f0=fun(x,A,B,C,alpha);
+    %Note sum(sum((P*A*Q').*B))=sum(sum(B*Q*A').*P)
+    %  so grad wrt to P is  B*Q*A'
+    g=reshape(2*(1-alpha)*B*Q*A' + alpha*C,m*m,1);
+    %Note sum(sum((P*A*Q').*B))=sum(sum(B'*P*A).*Q)
+    %  so grad wrt to Q is  B'*P*A
+    %g=-[g;reshape(B'*P*A,n*n,1)];
+    g=[g;reshape(2*(1-alpha)*B'*P*A + alpha*C,n*n,1)];
 

--- a/code/FAQ/graphm_sfw.m
+++ b/code/FAQ/graphm_sfw.m
@@ -1,0 +1,63 @@
+function [f,p,P,Q,iter,fs,myps]=graphm_sfw(A,B,IMAX,x0,C,alpha)
+% A wrapper around the sfw function for solving QAP to return values
+% instead relevant to graph matching
+
+% Perform at most IMAX iterations of the Frank-Wolfe method to compute an
+% approximate solution to the graph matching problem given the
+% matrices A and B. A and B should be square and the same size.  The method
+% seeks a permutatation p with corresponding matrix P(p) which minimizes
+%       g(p)=|| A - P(p)^T B P(p) ||_Fro
+% by minimizing
+%       f(p)=sum(sum(A.*B(p,p)))
+% Convergence is declared if a fix point is encountered or if the projected
+% gradient has 2-norm of 1.0e-4 or less.
+% IMAX is optional with a default value of 30 iterations.
+%     If IMAX is set to 0.5 then one iteration of FW is performed with no
+%     line search.  This is Carey Priebe's LAP approximation to the QAP.
+% The starting point is optional as well and its default value is
+% ones(n)/n, the flat doubly stochastic matrix.
+% x0 may also be
+%   -1 which signifies a "random" starting point should be used.
+%       here the start is given by
+%       0.5*ones(n)/n+sink(rand(n),10)
+%       where sink(rand(n),10) performs 10 iterations of Sinkhorn balancing
+%       on a matrix whose entries are drawn from the uniform distribution
+%       on [0,1].
+%   x0 may also be a user specified n by n doubly stochastic matrix.
+%   x0 may be a permutation vector of size n.
+% On output:
+%     f=|| A - P(p)^T B P(p) ||_Fro, where
+%     p is the permutation found by FW after projecting the interior point
+%         to the boundary.
+%     P is the permutation matrix corresponding to permutation p
+%     Q is the doubly stochastic matrix (interior point) computed by the FW
+%       method
+%     iter is the number of iterations of FW performed.
+%     fs is the list of fs for each iteration
+%     myps is the list of myps for each iteration
+
+    if ~exist('IMAX','var')
+        [~,p,Q,iter,fs,myps] = sfw(-A, B);
+        alpha = 1;
+        C = zeros(size(A));
+    elseif ~exist('x0','var')
+        [~,p,Q,iter,fs,myps] = sfw(-A, B, IMAX);
+        alpha = 1;
+        C = zeros(size(A));
+    elseif ~exist('C','var')
+        [~,p,Q,iter,fs,myps] = sfw(-A, B, IMAX, x0);
+        alpha = 1;
+        C = zeros(size(A));
+    elseif ~exist('alpha','var')
+        [~,p,Q,iter,fs,myps] = sfw(-A, B, IMAX, x0, C);
+        alpha = 1;
+    else
+        [~,p,Q,iter,fs,myps] = sfw(-A, B, IMAX, x0, C, alpha);
+    end
+    
+    P = perm2mat(p);
+    P = P';
+    f = (1-alpha)*norm(A - P' * B * P, 'fro') + alpha*trace(C' * P);
+
+end
+

--- a/code/FAQ/lines.m
+++ b/code/FAQ/lines.m
@@ -1,4 +1,4 @@
-function [f0new, salpha] = lines(type, x,d,g,A,B)
+function [f0new, salpha] = lines(type, x,d,g,A,B,C,alpha)
 %function [f0new, salpha] = lines(type, x,d,g,A,B)
 % line search: 0=> salpha=1, 1=> search
 %
@@ -19,7 +19,7 @@ Debug=0;
 
 dxg  = d'*g;
 if(dxg > 0)
-    fprintf(1,'warning: Nonimproving Direction, <d,g> = %g\n', dxg);
+    %fprintf(1,'warning: Nonimproving Direction, <d,g> = %g\n', dxg);
     %d=-d;
 end
 
@@ -160,9 +160,9 @@ elseif (type==2)
     % derivative at alpha=0:
     b = g' * d;
     % constant term at alpha=0
-    c = fun(x,A,B);
+    c = fun(x,A,B,C,alpha);
     % get second order coeff
-    fun_vertex = fun(x+d,A,B);
+    fun_vertex = fun(x+d,A,B,C,alpha);
     a = fun_vertex - b - c;
     if( abs(a)<eps)
         %disp('function is linear');
@@ -170,7 +170,7 @@ elseif (type==2)
     else
         salpha =min(1,max(-b/(2*a),0));
     end;
-    fun_alpha = fun(x+salpha*d,A,B);
+    fun_alpha = fun(x+salpha*d,A,B,C,alpha);
     % check quadratic function
     qfun_alpha = a*salpha*salpha + b*salpha + c;
     if ((abs(a)>=eps)&&(abs(fun_alpha-qfun_alpha)>1000*abs(fun_alpha)*eps))
@@ -190,7 +190,7 @@ else
 end
 
 xt=x + salpha*d;
-f0new = fun(xt,A,B);
+f0new = fun(xt,A,B,C,alpha);
 
 % salpha, f0new
 % lmin= fmin('fun1dim',0,alpha_c,[0,1.e-6],x,d,T,O,n,m,scale)

--- a/code/FAQ/sfw.m
+++ b/code/FAQ/sfw.m
@@ -41,6 +41,10 @@ function [f,myp,x,iter,fs,myps]=sfw(A,B,IMAX,x0)
 %
 [m,n]=size(A);
 stype=2;
+if ~exist('IMAX','var')
+    IMAX=30;
+end;
+
 if ~exist('x0','var')
     % If IMAX == 0.5 use the identity as the starting point, and perform
     % one iteration of FW with a step length of 1.
@@ -67,9 +71,7 @@ else
     x0=x0(:);
 end
 x=x0;
-if ~exist('IMAX','var')
-    IMAX=30;
-end;
+
 stoptol=1.0e-4;
 myp=[];
 iter=0; stop=0;

--- a/code/FAQ/sfw.m
+++ b/code/FAQ/sfw.m
@@ -1,4 +1,4 @@
-function [f,myp,x,iter,fs,myps]=sfw(A,B,IMAX,x0)
+function [f,myp,Q,iter,fs,myps]=sfw(A,B,IMAX,x0,C,alpha)
 %function [f,p,x,iter]=sfw(A,B,IMAX,x0)'
 % Perform at most IMAX iterations of the Frank-Wolfe method to compute an
 % approximate solution to the quadratic assignment problem given the
@@ -25,11 +25,14 @@ function [f,myp,x,iter,fs,myps]=sfw(A,B,IMAX,x0)
 %     f=sum(sum(A.*B(p,p))), where
 %     p is the permutation found by FW after projecting the interior point
 %         to the boundary.
-%     x is the doubly stochastic matrix (interior point) computed by the FW
+%     Q is the doubly stochastic matrix (interior point) computed by the FW
 %       method
 %     iter is the number of iterations of FW performed.
 %     fs is the list of fs for each iteration
 %     myps is the list of myps for each iteration
+%     C is the matrix of node labellings (a priori information)
+%     alpha is the weight we give to structure vs labels i.e.
+%         f = (1-alpha) * tr ( A P B^T P^T) + alpha * tr( C^T P )
 %
 % Louis J. Podrazik circa 1996
 % Modified by John M. Conroy, 1996-2010
@@ -72,13 +75,23 @@ else
 end
 x=x0;
 
+if ~exist('C', 'var')
+    % Default no labels
+    C = zeros(m,n);
+end
+
+if ~exist('alpha', 'var')
+    % Default all weight given to structure
+    alpha = 0;
+end
+
 stoptol=1.0e-4;
 myp=[];
 iter=0; stop=0;
 myps=nan(ceil(IMAX),n);
 while ( (iter < IMAX) && (stop==0))
     % ---- fun+grad ------
-    [f0,g] = fungrad(x,A,B);
+    [f0,g] = fungrad(x,A,B,C,alpha);
     g=[g(1:n^2)+g(1+n^2:end);g(1:n^2)+g(1+n^2:end)]/2;
     % ---- projection ------
     [d,myp] = dsproj(x,g,m,n);
@@ -91,7 +104,7 @@ while ( (iter < IMAX) && (stop==0))
     % ---- line search  ------
     %plotline( T,O, x,d,g,n,m,50);
     if IMAX>0.5
-        [f0new, salpha] = lines(       stype, x,d,g,A,B);
+        [f0new, salpha] = lines(       stype, x,d,g,A,B,C,alpha);
     else
         salpha=1;  % Priebe's LAP approximation to a QAP
     end


### PR DESCRIPTION
I added the graph labelling term `trace(C' P)` to the rQAP formulation in http://arxiv.org/pdf/1112.5507v5.pdf. The objective function is now (where `alpha` is chosen between 0 and 1):

```
2*(1-alpha)*trace(P*A*Q'*B) + alpha * trace(C'*P)
```

as opposed to previously 

```
trace(P*A*Q'*B)
```

I wrote some basic tests for it in code/FAQ/Tests. There is an issue with code/FAQ/lines.m now finding a quadratic search error at times. I believe this may be because the objective function has now changed but did not fully understand the function and this may not be working correctly for non integer `alpha`.

I also wrote a wrapper for the QAP solver so you can input adjacency matrices and fixed a small bug.

To test the new code, best to run the tests in code/FAQ/Tests.

P.S.

There are a couple of name changes I made to variables which I did before I thought I should contribute. I think they're fairly inconsequential.
